### PR TITLE
Asynchronous code cleanup

### DIFF
--- a/FrozenFantasy/Models/TournamentModel.swift
+++ b/FrozenFantasy/Models/TournamentModel.swift
@@ -8,16 +8,12 @@
 import Foundation
 
 typealias Tournaments = [Tournament]
-struct Tournament: Codable, Identifiable {
+struct Tournament: Codable, Identifiable, Equatable {
     var id: Int = UUID().hashValue
     var title: String
     var league: League
     var status: Status
-
-    var participatingString: String
-    var participating: Bool {
-        participatingString == "true"
-    }
+    var participating: Bool
 
     var startDate: Date
     var endDate: Date
@@ -31,7 +27,7 @@ struct Tournament: Codable, Identifiable {
         case title
         case league
         case status = "statusTournament"
-        case participatingString = "statusParticipation"
+        case participating = "statusParticipation"
 
         case startDate = "timeStartTS"
         case endDate = "timeEndTS"

--- a/FrozenFantasy/Preview Content/Dummies.swift
+++ b/FrozenFantasy/Preview Content/Dummies.swift
@@ -16,7 +16,7 @@ extension Tournament: Dummy {
         title: "NHL Daily Tournament",
         league: .NHL,
         status: .notStarted,
-        participatingString: "false",
+        participating: false,
         startDate: .now.advanced(by: 600),
         endDate: .now.advanced(by: 87000),
         players: 13,

--- a/FrozenFantasy/Views/Login/LoginViewModel.swift
+++ b/FrozenFantasy/Views/Login/LoginViewModel.swift
@@ -7,14 +7,14 @@
 
 import Foundation
 
-@MainActor final class LoginViewModel: ObservableObject {
+final class LoginViewModel: ObservableObject {
     @Published var email: String = ""
     @Published var password: String = ""
 
     @Published var isEmailValid: Bool = false
     @Published var isPasswordValid: Bool = false
 
-    @Published var errorMessage: String = ""
+    @MainActor @Published var errorMessage: String = ""
 
     var isValid: Bool {
         isEmailValid && isPasswordValid
@@ -32,8 +32,10 @@ import Foundation
 
             TokenManager.shared.save(tokenPair)
             await AppState.shared.setCurrentScreen(to: .main)
-        } catch APIError.badRequest(let reason) {
-            errorMessage = reason
+        } catch let APIError.badRequest(reason) {
+            await MainActor.run {
+                errorMessage = reason
+            }
         } catch {
             await AppState.shared.presentAlert(message: error.localizedDescription)
         }

--- a/FrozenFantasy/Views/Registration/RegistrationViewModel.swift
+++ b/FrozenFantasy/Views/Registration/RegistrationViewModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-@MainActor final class RegistrationViewModel: ObservableObject {
+final class RegistrationViewModel: ObservableObject {
     @Published var email: String = ""
     @Published var code: String = ""
 
@@ -19,7 +19,7 @@ import Foundation
     @Published var isNicknameValid: Bool = false
     @Published var isPasswordValid: Bool = false
 
-    @Published var errorMessage: String = ""
+    @MainActor @Published var errorMessage: String = ""
 
     var isValid: Bool {
         isEmailValid && isCodeValid && isNicknameValid && isPasswordValid
@@ -56,8 +56,10 @@ import Foundation
 
             TokenManager.shared.save(tokenPair)
             await AppState.shared.setCurrentScreen(to: .main)
-        } catch APIError.badRequest(let reason) {
-            errorMessage = reason
+        } catch let APIError.badRequest(reason) {
+            await MainActor.run {
+                errorMessage = reason
+            }
         } catch {
             await AppState.shared.presentAlert(message: error.localizedDescription)
         }

--- a/FrozenFantasy/Views/Root/Collection/CollectionView.swift
+++ b/FrozenFantasy/Views/Root/Collection/CollectionView.swift
@@ -27,6 +27,9 @@ struct CollectionView: View {
             .task {
                 await viewModel.fetchCards()
             }
+            .refreshable {
+                await viewModel.fetchCards()
+            }
         }
     }
 }

--- a/FrozenFantasy/Views/Root/Collection/CollectionViewModel.swift
+++ b/FrozenFantasy/Views/Root/Collection/CollectionViewModel.swift
@@ -7,20 +7,23 @@
 
 import Foundation
 
-@MainActor final class CollectionViewModel: ObservableObject {
-    @Published var cards: Cards = []
+final class CollectionViewModel: ObservableObject {
+    @MainActor @Published var cards: Cards = []
 
     func fetchCards() async {
         do {
             async let userID = NetworkManager.shared.request(
                 from: UserAPI.info,
                 expecting: User.self).id
-            cards = try await NetworkManager.shared.request(
+            let data = try await NetworkManager.shared.request(
                 from: PlayersAPI.playerCards(profileID: await userID,
                                              rarity: nil,
                                              league: nil,
                                              unpacked: nil),
                 expecting: Cards.self)
+            await MainActor.run {
+                cards = data
+            }
         } catch {
             await AppState.shared.presentAlert(message: error.localizedDescription)
         }

--- a/FrozenFantasy/Views/Root/Profile/ProfileView.swift
+++ b/FrozenFantasy/Views/Root/Profile/ProfileView.swift
@@ -13,7 +13,7 @@ struct ProfileView: View {
     var body: some View {
         NavigationView {
             ScrollView {
-                VStack(alignment: .leading, spacing: 24) {
+                LazyVStack(alignment: .leading, spacing: 24) {
                     headerView
 
                     TransactionsView(transactions: viewModel.transactions ?? [])
@@ -21,14 +21,8 @@ struct ProfileView: View {
                 .padding()
             }
             .navigationTitle("Профиль")
-
-            // MARK: Animation
-
             .animation(.default, value: viewModel.user)
             .animation(.default, value: viewModel.transactions)
-
-            // MARK: Fetch actions
-
             .task {
                 await viewModel.fetchUserInfo()
                 await viewModel.fetchTransactions()
@@ -37,9 +31,6 @@ struct ProfileView: View {
                 await viewModel.fetchUserInfo()
                 await viewModel.fetchTransactions()
             }
-
-            // MARK: Alerts
-
             .alert(isPresented: $viewModel.presentingLogoutAlert) {
                 Alert(
                     title: Text("Подтвердите действие"),
@@ -50,9 +41,6 @@ struct ProfileView: View {
                     secondaryButton: .cancel()
                 )
             }
-
-            // MARK: Toolbar
-
             .toolbar {
                 ToolbarItem(placement: .destructiveAction) {
                     Button {

--- a/FrozenFantasy/Views/Root/Profile/ProfileViewModel.swift
+++ b/FrozenFantasy/Views/Root/Profile/ProfileViewModel.swift
@@ -7,18 +7,21 @@
 
 import Foundation
 
-@MainActor final class ProfileViewModel: ObservableObject {
-    @Published var user: User?
-    @Published var transactions: Transactions?
+final class ProfileViewModel: ObservableObject {
+    @MainActor @Published var user: User?
+    @MainActor @Published var transactions: Transactions?
 
     @Published var presentingLogoutAlert = false
 
     func fetchUserInfo() async {
         do {
-            user = try await NetworkManager.shared.request(
+            let data = try await NetworkManager.shared.request(
                 from: UserAPI.info,
                 expecting: User.self
             )
+            await MainActor.run {
+                user = data
+            }
         } catch {
             await AppState.shared.presentAlert(message: error.localizedDescription)
         }
@@ -26,10 +29,13 @@ import Foundation
 
     func fetchTransactions() async {
         do {
-            transactions = try await NetworkManager.shared.request(
+            let data = try await NetworkManager.shared.request(
                 from: UserAPI.transactions,
                 expecting: Transactions.self
             )
+            await MainActor.run {
+                transactions = data
+            }
         } catch {
             await AppState.shared.presentAlert(message: error.localizedDescription)
         }

--- a/FrozenFantasy/Views/Root/Tournaments/TournamentsView.swift
+++ b/FrozenFantasy/Views/Root/Tournaments/TournamentsView.swift
@@ -13,7 +13,7 @@ struct TournamentsView: View {
     var body: some View {
         NavigationView {
             ScrollView {
-                VStack(spacing: 16) {
+                LazyVStack(spacing: 16) {
                     ForEach(viewModel.tournaments) { tournament in
                         NavigationLink {
                             TournamentDetailView(tournament)
@@ -23,11 +23,16 @@ struct TournamentsView: View {
                     }
                 }
                 .padding(16)
+                .frame(maxWidth: .infinity)
             }
             .navigationTitle("Турниры")
             .task {
                 await viewModel.getTournaments()
             }
+            .refreshable {
+                await viewModel.getTournaments()
+            }
+            .animation(.default, value: viewModel.tournaments)
         }
     }
 }

--- a/FrozenFantasy/Views/Root/Tournaments/TournamentsViewModel.swift
+++ b/FrozenFantasy/Views/Root/Tournaments/TournamentsViewModel.swift
@@ -7,18 +7,18 @@
 
 import Foundation
 
-@MainActor final class TournamentsViewModel: ObservableObject {
-    @Published var tournaments: Tournaments = []
-
-    @Published var alertMessage: String = ""
-    @Published var presentingAlert: Bool = false
+final class TournamentsViewModel: ObservableObject {
+    @MainActor @Published var tournaments: Tournaments = []
 
     func getTournaments() async {
         do {
-            tournaments = try await NetworkManager.shared.request(
+            let data = try await NetworkManager.shared.request(
                 from: TournamentsAPI.getTournaments(showAll: true, tournamentID: nil, league: nil, status: nil),
                 expecting: Tournaments.self
             ).sorted { $0.startDate > $1.startDate }
+            await MainActor.run {
+                tournaments = data
+            }
         } catch {
             await AppState.shared.presentAlert(message: error.localizedDescription)
         }


### PR DESCRIPTION
Moves the `@MainActor` attribute to the viewModels' class definitions to the properties, which allows the networking to run in the background and use the Main Actor only to set new values